### PR TITLE
Add 'unsafe' implementations for comparison

### DIFF
--- a/benchmarks/Main.hs
+++ b/benchmarks/Main.hs
@@ -6,6 +6,10 @@ import qualified Data.Sequence as Seq
 import System.Random
 import Data.Foldable
 
+import qualified Data.Traversable.Sort.List as L
+import qualified Data.Traversable.Sort.Seq  as S
+import qualified Data.Traversable.Sort.PQueue  as P
+
 main = do
   g <- getStdGen
   let million = take 1000000 $ randoms g :: [Int]
@@ -37,22 +41,37 @@ main = do
         [ bgroup "list"
           [ bench "Data.List"  $ nf sort tenthousand
           , bench "HSTrav"     $ nf sortTraversable tenthousand
+          -- , bench "List"       $ nf L.sortTraversable tenthousand
+          , bench "Seq"        $ nf S.sortTraversable tenthousand
+          , bench "PQueue"     $ nf P.sortTraversable tenthousand
           ]
         , bgroup "sequence"
           [ bench "sort"           $ nf Seq.sort tenthousand'
           , bench "unstableSort"   $ nf Seq.unstableSort tenthousand'
           , bench "HSTrav"         $ nf sortTraversable tenthousand'
+          , bench "List"           $ nf L.sortTraversable tenthousand'
+          , bench "Seq"            $ nf S.sortTraversable tenthousand'
+          , bench "PQueue"         $ nf P.sortTraversable tenthousand'
           ]
         ]
+
+    -- List performs poorly for lists, as then its O(n^2) insertion sort
+    -- For sequence it's more of a merge sort, so it's ok-ish.
     , bgroup "100000"
         [ bgroup "list"
           [ bench "Data.List"  $ nf sort hundredthousand
           , bench "HSTrav"     $ nf sortTraversable hundredthousand
+          -- , bench "List"       $ nf L.sortTraversable hundredthousand
+          , bench "Seq"        $ nf S.sortTraversable hundredthousand
+          , bench "PQueue"     $ nf P.sortTraversable hundredthousand
           ]
         , bgroup "sequence"
           [ bench "sort"           $ nf Seq.sort hundredthousand'
           , bench "unstableSort"   $ nf Seq.unstableSort hundredthousand'
           , bench "HSTrav"         $ nf sortTraversable hundredthousand'
+          , bench "List"           $ nf L.sortTraversable hundredthousand'
+          , bench "Seq"            $ nf S.sortTraversable hundredthousand'
+          , bench "PQueue"         $ nf P.sortTraversable hundredthousand'
           ]
         ]
     , bgroup "1000000"

--- a/sort-traversable.cabal
+++ b/sort-traversable.cabal
@@ -48,6 +48,11 @@ library
     Data.Traversable.Sort.PairingHeap.BasicNat
     Data.Traversable.Sort.PairingHeap.IndexedPairingHeap
 
+  exposed-modules:
+    Data.Traversable.Sort.List
+    Data.Traversable.Sort.Seq
+    Data.Traversable.Sort.PQueue
+
   -- Modules included in this library but not exported.
   -- other-modules:
 
@@ -64,7 +69,7 @@ library
     , RoleAnnotations
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.8 && <4.10
+  build-depends:       base >=4.8 && <4.17, containers, pqueue
 
   -- Directories containing source files.
   hs-source-dirs: src, benchmarks
@@ -81,7 +86,7 @@ benchmark bench
 
     Build-Depends:
         base      >= 4.4     && < 5
-      , criterion >= 1.1.1.0 && < 1.2
-      , containers  >=0.5 && <0.6
+      , criterion >= 1.1.1.0 && < 1.6
+      , containers  >=0.5 && <0.7
       , random
       , sort-traversable

--- a/src/Data/Traversable/Sort/List.hs
+++ b/src/Data/Traversable/Sort/List.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE GADTs #-}
+module Data.Traversable.Sort.List (
+    sortTraversable,
+) where
+
+data Sort a r where
+    Sort :: ([a] -> ([a], r)) -> [a] -> Sort a r
+
+instance Functor (Sort a) where
+    fmap f (Sort g xs) = Sort (\ys -> case g ys of (zs, r) -> (zs, f r)) xs
+
+instance Ord a => Applicative (Sort a) where
+    pure x = Sort (\xs -> (xs, x)) []
+
+    Sort f xs <*> Sort g ys = Sort h (merge xs ys) where
+        h zs = case f zs of
+            (zs', f') -> case g zs' of
+                (zs'', x') -> (zs'', f' x')
+
+liftSort :: Ord x => x -> Sort x x
+liftSort x = Sort (\ys -> case ys of
+                      []    -> ([], x) -- this shouldn't happen, but it's easy to fullfil anyway.
+                      y:ys' -> (ys', y)
+                  ) [x]
+
+runSort :: Sort x a -> a
+runSort (Sort f xs) = snd (f xs)
+
+merge :: Ord a => [a] -> [a] -> [a]
+merge []     ys     = ys
+merge xs     []     = xs
+merge (x:xs) (y:ys)
+    | x < y     = x : merge xs (y:ys)
+    | otherwise = y : merge (x:xs) ys
+
+-- | Sort an arbitrary 'Traversable' container using a heap.
+sortTraversable :: (Ord a, Traversable t) => t a -> t a
+sortTraversable = runSort . traverse liftSort
+{-# INLINABLE sortTraversable #-}

--- a/src/Data/Traversable/Sort/PQueue.hs
+++ b/src/Data/Traversable/Sort/PQueue.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE GADTs #-}
+module Data.Traversable.Sort.PQueue (
+    sortTraversable,
+) where
+
+import Data.PQueue.Min (MinQueue)
+import qualified Data.PQueue.Min as MinQueue
+
+data Sort a r where
+    Sort :: (MinQueue a -> (MinQueue a, r)) -> !(MinQueue a) -> Sort a r
+
+instance Functor (Sort a) where
+    fmap f (Sort g xs) = Sort (\ys -> case g ys of (zs, r) -> (zs, f r)) xs
+
+instance Ord a => Applicative (Sort a) where
+    pure x = Sort (\xs -> (xs, x)) MinQueue.empty
+
+    Sort f xs <*> Sort g ys = Sort h (xs <> ys) where
+        h zs = case f zs of
+            (zs', f') -> case g zs' of
+                (zs'', x') -> (zs'', f' x')
+
+liftSort :: Ord x => x -> Sort x x
+liftSort x = Sort (\ys -> case MinQueue.minView ys of
+                      Nothing       -> (MinQueue.empty, x) -- this shouldn't happen, but it's easy to fullfil anyway.
+                      Just (y, ys') -> (ys', y)
+                  ) (MinQueue.singleton x)
+
+runSort :: Sort x a -> a
+runSort (Sort f xs) = snd (f xs)
+
+-- | Sort an arbitrary 'Traversable' container using a heap.
+sortTraversable :: (Ord a, Traversable t) => t a -> t a
+sortTraversable = runSort . traverse liftSort
+{-# INLINABLE sortTraversable #-}

--- a/src/Data/Traversable/Sort/Seq.hs
+++ b/src/Data/Traversable/Sort/Seq.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE GADTs #-}
+module Data.Traversable.Sort.Seq (
+    sortTraversable,
+) where
+
+import Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
+
+data Sort a r where
+    Sort :: (Seq a -> (Seq a, r)) -> !(Seq a) -> Sort a r
+
+instance Functor (Sort a) where
+    fmap f (Sort g xs) = Sort (\ys -> case g ys of (zs, r) -> (zs, f r)) xs
+
+-- Note: no Ord!
+instance Applicative (Sort a) where
+    pure x = Sort (\xs -> (xs, x)) Seq.empty
+
+    Sort f xs <*> Sort g ys = Sort h (xs <> ys) where
+        h zs = case f zs of
+            (zs', f') -> case g zs' of
+                (zs'', x') -> (zs'', f' x')
+
+liftSort :: Ord x => x -> Sort x x
+liftSort x = Sort (\ys -> case ys of
+                      Seq.Empty     -> (Seq.Empty, x) -- this shouldn't happen, but it's easy to fullfil anyway.
+                      y Seq.:<| ys' -> (ys', y)
+                  ) (Seq.singleton x)
+
+-- Ord is here!
+runSort :: Ord x => Sort x a -> a
+runSort (Sort f xs) = snd (f (Seq.sort xs))
+
+-- | Sort an arbitrary 'Traversable' container using a heap.
+sortTraversable :: (Ord a, Traversable t) => t a -> t a
+sortTraversable = runSort . traverse liftSort
+{-# INLINABLE sortTraversable #-}


### PR DESCRIPTION
These are simpler, but we have on unreachable branch...

A noisy benchmark result:

![Screenshot from 2022-06-22 23-34-28](https://user-images.githubusercontent.com/51087/175131422-0bada533-cf8e-4be8-8f0e-ac01e02077d8.png)
